### PR TITLE
Texture loader

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -185,7 +185,25 @@ function Player(){
 
   this.cameraGravity = 10;
   this.getCameraGravity = function(){
-    return new THREE.Vector2(this.mesh.position.x * this.cameraGravity, this.mesh.position.y * this.cameraGravity);
+    var velocity = new THREE.Vector2(0, 0);
+    switch (this.currentDirection) { //future ronald, think of a better solution for this.
+      case 0:
+        velocity.y += 1;
+        break;
+      case 1:
+        velocity.x -= 1;
+        break;
+      case 2:
+        velocity.y -= 1;
+        break;
+      case 3:
+        velocity.x += 1;
+        break;
+    }
+    
+    velocity.multiplyScalar(this.speed);
+    velocity.add(this.mesh.position);
+    return new THREE.Vector2(velocity.x * this.cameraGravity, velocity.y * this.cameraGravity);
   }
 }
 

--- a/js/game.js
+++ b/js/game.js
@@ -46,17 +46,10 @@ function initGame() {
 
   {
 
-    //var texture = imageLoader.createSprite("wizard.png", 64, 64, 0, 0);
-    var texture = new THREE.Texture();
-    texture.image = imageLoader.image("wizard.png");
-    texture.needsUpdate = true;
-
-    console.log(texture);
+    var texture = imageLoader.createSprite("wizard.png", 468, 780, 0, 0);
     var material = new THREE.MeshBasicMaterial( {
       map: texture
     } );
-    //var material = new THREE.MeshBasicMaterial( { color: 0x0000ff } )
-
     player.animatedTexture = new AnimatedTexture(texture);
 
     var rectGeom = new THREE.ShapeGeometry( rectShape );
@@ -69,8 +62,8 @@ function initGame() {
     world[world.length] = player;
 
   }
-  {
 
+  {
     var texture = imageLoader.createSprite("tilesheet.png", 330, 372, 170, 100);
 
 
@@ -83,17 +76,17 @@ function initGame() {
     var newHouse = new House(texture, mesh, 10, -1);
     group.add(newHouse.mesh);
     world[world.length] = newHouse;
-
   }
 
   {
+    var texture = imageLoader.createSprite("tilesheet.png", 42, 57, 243, 3);
+    var material = new THREE.MeshBasicMaterial( {
+      map: texture
+    } );
 
-
-    var material = new THREE.MeshBasicMaterial( { color: 0xff00ff } )
     var rectGeom = new THREE.ShapeGeometry(rectShape );
     cameraLocationTest = new THREE.Mesh( rectGeom, material ) ;
     group.add(cameraLocationTest);
-
   }
 
   
@@ -321,11 +314,8 @@ function ImageLoader(imageFilenames){
     var ctx = canvas.getContext('2d');
     var dataTexture, data;
 
-    console.log(image);
-      
     ctx.drawImage(image, offset_x, offset_y, width, height, 0, 0, width, height);
     data = ctx.getImageData(0, 0, width, height);
-    console.log(data);
 
     dataTexture = new THREE.DataTexture(new Uint8Array(data.data.buffer), width, height, THREE.RGBAFormat);
     dataTexture.flipY = true;
@@ -334,43 +324,4 @@ function ImageLoader(imageFilenames){
     return dataTexture;
   }
 
-
-
 }
-
-//function TileSheet(filename){
-//  this.texture;
-//  this.material;
-//  this.isLoaded = false;
-//
-//  this.image = new Image();
-//  this.image.src = 'images/' + filename;
-//
-//  //loader.load('images/' + filename, function(texture){
-//  //  this.material = new THREE.MeshBasicMaterial( {
-//  //    map: texture
-//  //  } );
-//  //  this.texture = texture;
-//  //});
-//  //
-//  this.loaded = function(){
-//    tileSheet.createSprite(64,64,0, 0);
-//  }
-//
-//  this.image.onload = this.loaded;
-//
-//  this.createSprite = function(width, height, offset_x, offset_y){
-//    var canvas = document.createElement('canvas'),
-//      ctx = canvas.getContext('2d'),
-//      width = this.image.width,
-//      height = this.image.height,
-//      finalData, data;
-//
-//    ctx.drawImage(this.image, offset_x, offset_y, width, height);
-//    this.texture = new THREE.Texture(canvas);
-//    
-//    //finalData = ctx.getImageData(0, 0, width, height);
-//    //finalData.data;
-//
-//  }
-//}

--- a/js/game.js
+++ b/js/game.js
@@ -123,9 +123,10 @@ function render() {
   for(index in world){
     if (world[index].mesh.position.distanceTo(player.mesh.position) > viewCorrectionDistance)
       continue;
-    cameraPosition.x += (world[index].mesh.position.x * world[index].cameraGravity) / sumIntensity;
-    cameraPosition.y += (world[index].mesh.position.y * world[index].cameraGravity) / sumIntensity;
+    cameraPosition.add(world[index].getCameraGravity());
   }
+
+  cameraPosition.divideScalar(sumIntensity);
 
   if (cameraLocationTest){
     cameraLocationTest.position.x = cameraPosition.x;
@@ -150,8 +151,6 @@ function Player(){
   this.animatedTexture;
   this.mesh;
   this.speed = 2.0;
-  this.cameraGravity = 10;
-
   this.update = function(dt){
     if (!this.mesh)
       return;
@@ -182,6 +181,11 @@ function Player(){
       this.animatedTexture.update(dt);
     }
 
+  }
+
+  this.cameraGravity = 10;
+  this.getCameraGravity = function(){
+    return new THREE.Vector2(this.mesh.position.x * this.cameraGravity, this.mesh.position.y * this.cameraGravity);
   }
 }
 
@@ -262,7 +266,11 @@ function House(texture, mesh, x, y){
   this.mesh.scale.y = 5;
   this.mesh.position.x = x;
   this.mesh.position.y = y;
+
   this.cameraGravity = 3;
+  this.getCameraGravity = function(){
+    return new THREE.Vector2((this.mesh.position.x + 2.5) * this.cameraGravity, (this.mesh.position.y + 2.5) * this.cameraGravity);
+  }
 }
 
 

--- a/js/game.js
+++ b/js/game.js
@@ -37,6 +37,7 @@ function initGame() {
   rectShape.lineTo( rectLength, rectWidth );
   rectShape.lineTo( rectLength, 0 );
   rectShape.lineTo( 0, 0 );
+  
 
 
   var group = new THREE.Group();
@@ -70,7 +71,7 @@ function initGame() {
   }
   {
 
-    var texture = imageLoader.createSprite("tilesheet.png", 256, 512, 170, 100);
+    var texture = imageLoader.createSprite("tilesheet.png", 330, 372, 170, 100);
 
 
     var material = new THREE.MeshBasicMaterial( {
@@ -105,6 +106,7 @@ function initGame() {
   
 
   render();
+
 }
 
 // cube.position.z = 3;
@@ -314,9 +316,12 @@ function ImageLoader(imageFilenames){
   this.createSprite = function (filename, width, height, offset_x, offset_y){
     var image = this.image(filename);
     var canvas = document.createElement('canvas');
+    canvas.setAttribute('width', width);
+    canvas.setAttribute('height', height);
     var ctx = canvas.getContext('2d');
     var dataTexture, data;
 
+    console.log(image);
       
     ctx.drawImage(image, offset_x, offset_y, width, height, 0, 0, width, height);
     data = ctx.getImageData(0, 0, width, height);
@@ -325,6 +330,7 @@ function ImageLoader(imageFilenames){
     dataTexture = new THREE.DataTexture(new Uint8Array(data.data.buffer), width, height, THREE.RGBAFormat);
     dataTexture.flipY = true;
     dataTexture.needsUpdate = true;
+    dataTexture.wrapS = dataTexture.wrapT = THREE.ClampToEdgeWrapping;
     return dataTexture;
   }
 

--- a/test.html
+++ b/test.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=utf-8>
+    <title>test page</title>
+    <style>
+      body { margin: 0; }
+      canvas { width: 100%; height: 100% }
+
+      .buttons, .axes {
+        padding: 1em;
+      }
+
+      .button {
+        padding: 1em;
+        border-radius: 20px;
+        border: 1px solid black;
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAAxJREFUCNdjYPjPAAACAgEAqiqeJwAAAABJRU5ErkJggg==);
+        background-size: 0% 0%;
+        background-position: 50% 50%;
+        background-repeat: no-repeat;
+      }
+
+      .pressed {
+        border: 1px solid red;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="text/javascript">
+
+
+      function findNextPowOf2(value){
+        var n = 0;
+        while((1 << n) < value) n++;
+        return n;
+      }
+
+      var image = new Image();
+      image.src = "./images/tilesheet.png";
+      image.onload = function(){
+        var width = 330;
+        var height = 374;
+        findNextPowOf2(257);
+        var canvas = document.createElement('canvas');
+        var ctx = canvas.getContext('2d');
+        canvas.setAttribute('width', width);
+        canvas.setAttribute('height', height);
+        ctx.drawImage(image, 170, 100, width, height, 0, 0, width, height);
+      };
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
Texture loader implementer.

The idea is to preload the images at the start into image files. 

``` javascript
var images = ["tilesheet.png", "wizard.png", "house.png"];
var imageLoader = new ImageLoader(images);
```

Textures are then created based on the image by cropping them into a canvas.
When creating a world object (like a player) which uses a texture you can use:

``` javascript
Player.texture = imageLoader.createSprite("wizard.png", 468, 780, 0, 0);
```

This setup will make sure that the image is loaded before hand and only once.
Perhaps a feature to resize the texture (not by stretching but appending) to the next power of 2 (...64, 128, 256). 
This would ~~kill the crab~~ fix the wGL warnings. 
